### PR TITLE
Fix typos and grammar across blog content

### DIFF
--- a/v2/content/compendium/_index.md
+++ b/v2/content/compendium/_index.md
@@ -2,5 +2,5 @@
 title = "Compendium"
 +++
 
-Compendium are topical resources intended to be kept up to date instead of a stream-of-consciousness of notes.
+Compendium is a collection of topical resources intended to be kept up to date instead of a stream-of-consciousness of notes.
 

--- a/v2/content/compendium/oop.md
+++ b/v2/content/compendium/oop.md
@@ -4,7 +4,7 @@ date = 2025-07-24T01:51:17-07:00
 tags = ['compendium', 'ai-written']
 +++
 
-Object Oriented Programming is really two different ideas: message-passing and compile-time hierarchies. The former informs modern distributed systems and the latter is the basis of popular mordern programming architectures.
+Object Oriented Programming is really two different ideas: message-passing and compile-time hierarchies. The former informs modern distributed systems and the latter is the basis of popular modern programming architectures.
 
 | Problem | Small-talk / Message Passing Lineage | Modern / Compile-Time Lineage |
 | --------- | --------------- | ------ |
@@ -14,9 +14,9 @@ Object Oriented Programming is really two different ideas: message-passing and c
 | Calling a method implementation is ... | Asynchronous and knowable only at runtime | Synchronous and compile-time known |
 | Iterating on Program Development by ... | Updating one object at a time while preserving state, Limited type checking | Compile-time, Static type checking, Update full program by reseting state |
 
-While both are technically about objects, one focuses on using mechnanisms of messages to solve problems, while the other focuses on using classes and inheritance to solve problems.
+While both are technically about objects, one focuses on using mechanisms of messages to solve problems, while the other focuses on using classes and inheritance to solve problems.
 
-An small example would be about deferring some code to be executed later "in the background":
+A small example would be about deferring some code to be executed later "in the background":
 
 ```objc
 // objective-c: message passing style
@@ -35,7 +35,7 @@ timer.schedule(new TimerTask() {
 }, 1000);
 ```
 
-In the first class, messages are values that are passed along to a method that will do the scheduling work. In the modern style, there is a clearer structure for a type checker to know if its safe to call the method on the given object.
+In the first case, messages are values that are passed along to a method that will do the scheduling work. In the modern style, there is a clearer structure for a type checker to know if its safe to call the method on the given object.
 
 
 ## Lisp Origins
@@ -50,7 +50,7 @@ Notably, Kay later expressed regret about his terminology choice:
 
 > "I'm sorry that I long ago coined the term 'objects' for this topic because it gets many people to focus on the lesser idea. The big idea is messaging".
 
-Aside: A fun note is the CLOS adds object-oriented programming as a library in LISP because of its powerful macro system.
+Aside: A fun note is that CLOS adds object-oriented programming as a library in LISP because of its powerful macro system.
 
 ## Message Passing vs Modern OOP
 
@@ -82,7 +82,7 @@ The C++ lineage (C++, Java, C#) evolved away from Kay's vision toward more pract
 
 **Full-Program Compilation**: Rather than updating objects in a live system, modern approaches recompile entire programs.
 
-**Extending via Inheritance**: Modern OOP languages use inheritance to extend behavior, which can lead to rigid class hierarchies and the "fragile base class" problem. Interfaces are typically a no-implmentation-copying form of inheritance.
+**Extending via Inheritance**: Modern OOP languages use inheritance to extend behavior, which can lead to rigid class hierarchies and the "fragile base class" problem. Interfaces are typically a no-implementation-copying form of inheritance.
 
 **Static System**: Modern OOP languages typically require stopping the system to update code, which is a departure from Kay's live system vision.
 
@@ -96,7 +96,7 @@ While compile-time hierarchies are faster than message passing within a single p
 
 Interestingly, Erlang's creators didn't initially know about the Actor Model when they designed their language, but ended up creating something remarkably aligned with Kay's original vision. The problems Erlang was trying to solve (reliability, replication, redundancy) are the same nature was trying to solve when it evolved cells, and Alan Kay explicitly modeled OO on biological cells.
 
-Erlang extends massage-passing OOP principles to distributed systems:
+Erlang extends message-passing OOP principles to distributed systems:
 
 **Isolated Actors**: Erlang processes can only communicate via messages, with immutable boundaries preventing actors from passing mutable references or altering another actor's state.
 
@@ -123,7 +123,7 @@ In Orleans:
 - Virtual Actors are called Grains. Grains can be found via unique id defined ahead of time (e.g. - email address of the user)
 - Grains are accessed through a Silo, which manages each grain's lifecycle and distribution. Unique ids of grains are by silo.
 
-Aside: Orleans is commonly use for Xbox Live multiplayer servers since it allows dynamically scaling up and down based on player activity, with actors representing game sessions, players, and other entities. It has been used in the Halo 4.
+Aside: Orleans is commonly used for Xbox Live multiplayer servers since it allows dynamically scaling up and down based on player activity, with actors representing game sessions, players, and other entities. It has been used in the Halo 4.
 
 #### Cloudflare Durable Objects: JavaScript Virtual Actors
 
@@ -191,7 +191,7 @@ Modern microservices architecture embodies many of Kay's original principles:
 - [Proto.Actor][proto-actor]: is another implementation of virtual actors in .NET and Go
 - [Microservices][microservices]: Modern architecture that embodies OOP principles through encapsulation, message communication, and late binding.
 - [Actor Model][actor-model]: A conceptual model for building distributed systems where independent entities communicate through messages, closely aligned with Kay's original vision.
-- Casey Muratori's ["The Big OOPs"][the-big-oops] talk has better origins. He's delinination about compile-time class heirarchies is a useful form of OOP.
+- Casey Muratori's ["The Big OOPs"][the-big-oops] talk has better origins. He's delineation about compile-time class hierarchies is a useful form of OOP.
 - Entity Component System (ECS): A different approach to structuring software programs where state is not hidden within objects, but rather shared across components.
 
 [alan kay]: https://en.wikipedia.org/wiki/Alan_Kay

--- a/v2/content/resume/index.md
+++ b/v2/content/resume/index.md
@@ -15,7 +15,7 @@ in [my Github profile][github]._
 ## Goals
 
 My professional goal is continuous growth and learning. This can be as broad as
-handling a financial audits. Or as narrow as using a new technology. I revel in
+handling financial audits. Or as narrow as using a new technology. I revel in
 collaborating with my peers or other roles. Communicating is not just
 enunciating one's intent, but to make sure terminology used by different
 professions are aligned.
@@ -68,7 +68,7 @@ of thousands of dollars a month in costs.
 
 It's best explained through examples:
 
- - Faciliated miscommunications between departments (e.g. marketing and
+ - Facilitated miscommunications between departments (e.g. marketing and
    finance; marketing and co-founders; etc.).
  - Handled the work related to a tax reporting & audits (reviewed by the CFO)
  - Designed and rolled out Data Privacy and Compliance initiatives (CCPA, CPRA, etc.)
@@ -84,12 +84,12 @@ It's best explained through examples:
  - Set processes up for majority of the company for remote work (because of the pandemic)
  - Onboard new C-level and VP-level hires
  - Set roadmap for Founder's desired offerings and customer messaging
- - Started & completed the entire company from LastPass to 1Password, including
+ - Migrated the entire company from LastPass to 1Password, including
    personally walking through the process with each employee to ensure a
    seamless transition.
  - Negotiating with Vendors for Data, Engineering, Product, Retail, and
    Marketing SaaS. Saving the company $50k+/year in costs on this line item
-   along.
+   alone.
  - Evaluating consulting firms.
  - Helped HR migrate to Rippling from 
 
@@ -108,7 +108,7 @@ Feb 2020 - July 2021 · 1 yr 6 mos
 
 I exchanged engineering-specific duties for more communication and cross-functional related ones:
 
- - Talked with with Investors for technical due diligence.
+ - Talked with Investors for technical due diligence.
  - Vendor search & evaluation for nearly every SaaS for the company, such as
    find POS vendors and systems for expanding into retail.
  - Mentoring other department heads (peers) with career growth.
@@ -255,20 +255,20 @@ Taken courses in: Computer Graphics, Compilers, Cryptography, Network Programmin
 
 Sep 2011 - 2013
 
-YACS is an simple course scheduler for my school, RPI. It reads from various
+YACS is a simple course scheduler for my school, RPI. It reads from various
 data sources from RPI's sites and aggregates them into a unified form. Students
 can select their courses and view possible schedules. By end of the first year,
 it was used by 80% of the student body to the point that new students were
 recommended to use it.
 
-I did majority of work. Another student did help with support (looking through
+I did the majority of work. Another student did help with support (looking through
 our school's reddit) and another helped me make flyers. Years later, it
 took RCOS a team of students to replace and build most (but not all) the
-fatures of the original. The most complicated feature was building to conflict
+features of the original. The most complicated feature was building the conflict
 detection algorithm: the site could tell you why a course time was not
 available (which one of your selections cause a conflict) as you were selecting.
 
-Noteable features:
+Notable features:
 
  - Conflict Detection
  - Calendar Export (ics)
@@ -276,7 +276,7 @@ Noteable features:
  - Showing seats available
  - Mobile-friendly (iPhone, Android, Windows Phone)
 
-There was several rewrites in the course of 4 months:
+There were several rewrites in the course of 4 months:
 
  - CoffeeScript => JavaScript
  - jQuery => Backbone => Angular + Underscore

--- a/v2/content/writings/2014/01-evaluating-techonologies.md
+++ b/v2/content/writings/2014/01-evaluating-techonologies.md
@@ -5,11 +5,11 @@ draft = false
 url = "/2014/01-evaluating-technologies.html"
 +++
 
-Every time you look at a new (or familiar) technology. You should ask: What are
+Every time you look at a new (or familiar) technology, you should ask: What are
 the tradeoffs?
 
 It's obvious to see the benefits of something - it's generally advertised
-everywhere. Everyone is always shouting the the pros of X.
+everywhere. Everyone is always shouting the pros of X.
 
 - "X does Y easier"
 - "X does Y faster"
@@ -26,7 +26,7 @@ These are harder to find. Especially when the library is relatively new. But you
 can imagine based on how critical it is on your software stack.
 
 For example, but I'm not exclusively selecting, Mongodb. It is easier and faster
-is than a traditional SQL database, but that's because it sacrifices many
+than a traditional SQL database, but that's because it sacrifices many
 capabilities that a SQL database provides:
 
 - fsync (is off by default)

--- a/v2/content/writings/2014/02-adapting-binary-search.md
+++ b/v2/content/writings/2014/02-adapting-binary-search.md
@@ -52,7 +52,7 @@ Let’s look at the problem again:
 > We want to find **the number of words** that can be allowed to display.
 
 If we visualize the possible solutions, it’s just like searching through a
-sorted array items:
+sorted array of items:
 
 ```
 Number of words that fit in the given size:
@@ -60,7 +60,7 @@ Number of words that fit in the given size:
 ```
 
 The slight change we have to make from the traditional algorithm is ensure our
-algorithm remembers the number words it last seen that fits the given bound box.
+algorithm remembers the number of words it last saw that fits the given bound box.
 So if the final “item” we reach doesn’t fit, we know a fall-back that fits.
 
 ```
@@ -79,7 +79,7 @@ So if the final “item” we reach doesn’t fit, we know a fall-back that fits
 Selects 6 words.
 ```
 
-The performance improvement great because checking of the comparison fits is
+The performance improvement is great because checking of the comparison fits is
 expensive. This matches the same cost function of
 [Big-O notation](http://en.wikipedia.org/wiki/Big_O_notation), where number of
 items “visited” is measured.

--- a/v2/content/writings/2014/03-reverse-engineering-objective-c.md
+++ b/v2/content/writings/2014/03-reverse-engineering-objective-c.md
@@ -41,7 +41,7 @@ In the early days, Objective-C compiled to C. To be compatible with C, it used
 symbols that would normally be invalid for C. This explains why Objective-C uses
 @ for many of its keywords.
 
-In fact, Objective-C methods are simply c-functions. So lets look at how
+In fact, Objective-C methods are simply c-functions. So let's look at how
 `-[_doSomethingSpecial:]` would be defined in C:
 
 ```objc
@@ -79,7 +79,7 @@ Objective-C types are stripped at compile-time (properties are the exception).
 But getting the types just takes some more laborious effort. No problem, it’s
 just a bit more work to walk through it using a debugger.
 
-Of course, if you like reading assembly, you can using something like
+Of course, if you like reading assembly, you can use something like
 [Hopper](http://www.hopperapp.com) to open the binary files and read the
 implementation.
 
@@ -125,7 +125,7 @@ lldb> break set --addr 0xdeadbeef
 
 ## Combining Everything
 
-So lets have a look at the assembly in the debugger:
+So let's have a look at the assembly in the debugger:
 
 ```
 $ lldb # assuming app is already running

--- a/v2/content/writings/2014/04-objective-c-lazy-sequences.md
+++ b/v2/content/writings/2014/04-objective-c-lazy-sequences.md
@@ -39,7 +39,7 @@ for link in links {
 }
 ```
 
-This creates a powerful abstract that separate tasks your program needs to get
+This creates a powerful abstraction that separates tasks your program needs to get
 done behind an implicit interface. The ending for loop doesn't need to know that
 those links came from multiple page fetches or the file system. If the loop
 short-circuited, then it minimizes the number of unnecessary fetches.
@@ -170,7 +170,7 @@ doesn't require walking key-value pairs and instead only lazily realizes
 values).
 
 There are tradeoffs for a relatively elegant design. You lose potential
-performance gains for using the abstaction -- like random access on your data
+performance gains for using the abstraction -- like random access on your data
 structure's elements. Also, laziness makes standard debugging techniques
 difficult. Stacktraces are less comprehensible because the execution order no
 longer reads procedurally. This is a common complaint of

--- a/v2/content/writings/2014/05-Parsing-JSON-in-Objective-C-Part-1.html.md
+++ b/v2/content/writings/2014/05-Parsing-JSON-in-Objective-C-Part-1.html.md
@@ -5,7 +5,7 @@ tags = ["Objective-C", "Testing", "Series: Parsing JSON in Objective-C"]
 url = "2014/05-Parsing-JSON-in-Objective-C-Part-1.html"
 +++
 
-_This post was original written on the
+_This post was originally written on the
 [Pivotal Labs Blog](http://pivotallabs.com/parsing-json-in-objective-c)._
 
 JSON parsing is a frequent task for clients interfacing with any recent web API.
@@ -153,7 +153,7 @@ All done, ship it! But what about the error cases?
 
 You're probably cringing right now because there's no error handling yet:
 
-- What happens if the JSON doesn't parsed successfully?
+- What happens if the JSON doesn't parse successfully?
 - What if JSON keys don't exist?
 - Are the types of the JSON objects that we expect?
 
@@ -420,7 +420,7 @@ Finished in 0.1280 seconds
 
 The full code is the
 [tagged here](https://github.com/jeffh/ParsingJSON/tree/03-error-handling-height-key).
-So we finished our Red and Green. Now its time to…
+So we finished our Red and Green. Now it's time to…
 
 # Refactor
 

--- a/v2/content/writings/2014/06-Parsing-JSON-in-Objective-C-Part-2.html.md
+++ b/v2/content/writings/2014/06-Parsing-JSON-in-Objective-C-Part-2.html.md
@@ -369,7 +369,7 @@ example is a generic object-to-object mapper - we can build a mapper that:
 All of which builds on top of existing functionality. A perfect example is
 [Hydrant](https://github.com/jeffh/Hydrant)’s
 [ReflectiveMapper class](https://github.com/jeffh/Hydrant/blob/b9bfad919dd61f49d5b869788690dbd312a72a68/Hydrant/Public/Mappers/Facade/HYDReflectiveMapper.m#L227-286)
-(which is verbose simply because it is an immutable builder too). Most of it’s
+(which is verbose simply because it is an immutable builder too). Most of its
 functionality is achieved by composing other objects in Hydrant.
 
 ## Try it at Home

--- a/v2/content/writings/2015/07-Generative-Testing.html.md
+++ b/v2/content/writings/2015/07-Generative-Testing.html.md
@@ -12,7 +12,7 @@ fascinated in the functional programming community. Generative testing in
 particular. It was popularized in the early 2000s by a famous implementation in
 Haskell, [QuickCheck][QuickCheck].
 
-In short, generative testing is allows you specify properties your software
+In short, generative testing allows you to specify properties your software
 should have. Then the testing library _generates_ test cases. It's an
 alternative path the functional community has taken when it comes to testing.
 This becomes evident since testing functional code becomes mostly boilerplate
@@ -77,7 +77,7 @@ common ways of writing property-based tests are:
 - **Describe an inverse relationship using multiple functions.** A good example
   of this is encoding and decoding. A property test of JSON encoding can be that
   `decode(encode(value)) == value`.
-- **Describe a relationship of the inputs to its outputs.** The concatentation
+- **Describe a relationship of the inputs to its outputs.** The concatenation
   of two arrays preserves sizes: `len(a) + len(b) == len(a + b)`.
 - **Use an existing implementation.** Use an array to test a circular buffer
   implementation. Or use an existing base64 encoder to test your new faster
@@ -86,13 +86,13 @@ common ways of writing property-based tests are:
 Generative tests shine for exploratory testing where edge cases tend to surface
 bugs. But it's not a complete replacement to a traditional test suite. An
 example-based test suite can reliably reproduce significant cases: a known
-happy-path or a previously discovered bug. Both suites compliment each other
+happy-path or a previously discovered bug. Both suites complement each other
 well.
 
 Instead of focusing on ease of writing and maintaining tests, generative testing
 focuses on discovering new bugs.
 
-An implementation of QuickCheck is also [particularly fasinating][test.check].
+An implementation of QuickCheck is also [particularly fascinating][test.check].
 It's a great example of a well-designed functional program. If you're interested
 in an implementation for Objective-C and Swift, check out [Fox][fox].
 

--- a/v2/content/writings/2015/08-moving-on.html.md
+++ b/v2/content/writings/2015/08-moving-on.html.md
@@ -10,13 +10,13 @@ Labs. I met a lot of great friends. I paired and talked with geniuses and
 newcomers alike. And I'd recommend anyone with an opportunity to work at Labs to
 take it immediately.
 
-I look back with great memories, shared termoil, and personal growth. As an
-introvert, it was a boundary-expanded endevor: pair programming every day. I
+I look back with great memories, shared turmoil, and personal growth. As an
+introvert, it was a boundary-expanded endeavor: pair programming every day. I
 learned the value of tests which is evident to most of the major open source
 work I've contributed to. I've sharpened my mind by the discussions I've had
 there.
 
-Pivotal provided accelerated growth that I couldn't have receive from normal
+Pivotal provided accelerated growth that I couldn't have received from normal
 companies. Labs provides a unique way to learn on a wide range of skills in a
 few years:
 
@@ -37,7 +37,7 @@ Also, I learned about **the people that create software**:
 - What can make people productive.
 - Communicating well is a tough problem.
 
-I thank everyone who I have had the chance to worked with. I thank you pair for
+I thank everyone who I have had the chance to work with. I thank you pair for
 letting me type (I love it a bit too much) and experiencing how much I fail at
 pressing the right buttons too. **Please, keep in touch**.
 
@@ -45,7 +45,7 @@ But it's time to experience startup life. I'll be joining
 [Mayvenn](https://mayvenn.com/) working on Clojure full-time. The clojure
 community has been a place I have been _stealing ideas_ from since Clojure was
 first released into the world. It's a special opportunity to use this language
-in anger. It's impossible to have a perfect langauge, but it doesn't hurt to
+in anger. It's impossible to have a perfect language, but it doesn't hurt to
 expand to new forms of thought. That's for another article.
 
 As a polyglot, I'm impartial to tying any individual programming language. I've

--- a/v2/content/writings/2015/09-seeking-simplicity.html.md
+++ b/v2/content/writings/2015/09-seeking-simplicity.html.md
@@ -34,7 +34,7 @@ get less code by:
 - using arbitrary memory locations for code or shared lookups.
 
 For example, `if` and `for` are two separate concepts stemming from `goto`. But
-we don't complain about how `goto`s lead to to more complex code. But `if` and
+we don't complain about how `goto`s lead to more complex code. But `if` and
 `for` aren't difficult concepts for us to grasp because we're familiar with
 concepts from past experience.
 
@@ -56,7 +56,7 @@ code empathy to understand how much each module knows about one another:
 - Do all collaborators need to know about this ordering?
 - Does a collaborator expect specific side effects?
 - Do collaborators share state?
-- Does a object know about it's collaborator's collaborators?
+- Does an object know about its collaborator's collaborators?
 
 It's a perfect example of compartmentalization are typical usages of Ruby's
 `include` for modules. It is only a method of splitting a class' code across
@@ -64,8 +64,8 @@ multiple files instead of splitting its responsibilities into separate objects.
 
 ## JavaScript
 
-Unsuprisingly, this simplicity is what makes Clojure (and other LISPs)
-compelling. LISPs are simpler than most other progamming languages.
+Unsurprisingly, this simplicity is what makes Clojure (and other LISPs)
+compelling. LISPs are simpler than most other programming languages.
 
 Let's compare by trying describe the syntax of JavaScript (without pulling in
 compiler theory). If we're explain what's the meaning of every syntactic feature
@@ -96,7 +96,7 @@ of JavaScript, it would be something like this:
   - `function foo(bar, baz...) { statements }` is a function definition.
     Definitions are implicitly above other statements within the same list of
     statements.
-  - `function(bar, baz...) { statements }` is an annoymous function
+  - `function(bar, baz...) { statements }` is an anonymous function
   - `foo.bar` is accessing the `bar` property of object `foo`
   - `foo['bar']` is accessing the `bar` property of object `foo`. Does not bind
     `this`.
@@ -133,7 +133,7 @@ a syntactic level:
 This isn't covering what's inside a standard library of JavaScript (node,
 browers, etc). Libraries are not technically part of the language itself.
 
-And JavaScript is argubly one of the easier languages to write up these rules in
+And JavaScript is arguably one of the easier languages to write up these rules in
 comparison to Python, Java, or C.
 
 Now let's look at how simple Clojure (a LISP) is in comparison:
@@ -217,13 +217,13 @@ Clojure avoids complexity common in other languages:
 Both Clojure and JavaScript are trying to solve a problem of expressing
 programs. But one seems to do it with fewer internal components.
 
-It's worth noting that Clojure could be simplier. Rich has made tradeoffs to
+It's worth noting that Clojure could be simpler. Rich has made tradeoffs to
 leverage the JVM. State management is explicit, but not simple. Even something
 as small as ordered argument parameters for functions is a tradeoff in concision
 over potential readability.
 
 But Clojure **isn't easy**. It's a departure from the C-family of languages.
-Clojure has large (Jvava) stacktraces. It's common to hear developers complain
+Clojure has large (Java) stacktraces. It's common to hear developers complain
 about the number of parentheses. But it's analogous to multi-responsibility
 classes in OO. Large objects can be an entirely separate article. Easy is
 something we can overcome. Complexity we can only paint over.

--- a/v2/content/writings/2015/10-software-bridges/index.md
+++ b/v2/content/writings/2015/10-software-bridges/index.md
@@ -46,7 +46,7 @@ immediately, from the environment it operates under. The feedback loop is fast -
 like building things out of Lego.
 
 Because it's so easy to build on the shoulders of the past giants, the industry
-quickly falls into becoming overmodularized and underdiciplined. It's hard to
+quickly falls into becoming overmodularized and undisciplined. It's hard to
 build interconnected components when there are many competing, incompatible
 modules. And since it's easy to course correcting along the way, the final
 result is usually inconsistent - beams of inconsistent lengths as the project
@@ -75,9 +75,9 @@ In review, there's a lot of challenges:
 - Instrumentation to identify problems.
 - Tooling for operators to use.
 - Maintain High adaptability because:
-  - it's riders always want new features (lights, new vehicles, scenery/trees,
+  - its riders always want new features (lights, new vehicles, scenery/trees,
     etc.)
-  - it's operators/owners want other changes more internal
+  - its operators/owners want other changes more internal
 
 The last bullet is the one of the main reasons software is interesting to work
 on. How do you design a system that is highly adaptable with as few different

--- a/v2/content/writings/2015/11-mental-schemas/index.md
+++ b/v2/content/writings/2015/11-mental-schemas/index.md
@@ -39,7 +39,7 @@ successful algorithms are based on neuroscience. That doesn't preclude you from
 working in your current field, but it's a way to curate ideas and techniques you
 wouldn't otherwise have.
 
-While exploring other fields is much easier to learn a breath of information.
+While exploring other fields is much easier to learn a breadth of information.
 Narrowing solidifies the knowledge already known. It's similar to starting out
 as a civil engineer before learning physics. The engineering brings practical
 experience to theory. It provides intuition to theoretical concepts. This fills
@@ -140,7 +140,7 @@ location of every piece.
 
 <ol class="footnotes">
 <li id="1" class="footnote">This monthly blog posting is a mixed success. It's definitely on the trudging side of projects. <a class="back" href="#1-back">&#9166;</a></li>
-<li id="2" class="footnote">There's more than just mapping OO concepts to FP, but it's definite suprising to see how many can be mapped to functions. <a class="back" href="#2-back">&#9166;</a></li>
+<li id="2" class="footnote">There's more than just mapping OO concepts to FP, but it's definitely surprising to see how many can be mapped to functions. <a class="back" href="#2-back">&#9166;</a></li>
 </ol>
 
 [1]: https://en.wikipedia.org/wiki/A*_search_algorithm

--- a/v2/content/writings/2015/12-communicating-as-an-engineer.html.md
+++ b/v2/content/writings/2015/12-communicating-as-an-engineer.html.md
@@ -6,7 +6,7 @@ tags = ["Concepts", "Processes"]
 +++
 
 As an engineer, one of the most valuable skills you can have is to communicate
-effectively. This applies both to your follow engineers as well as non-engineers
+effectively. This applies both to your fellow engineers as well as non-engineers
 (PMs, designers, business). Obviously, this advice is generally applicable, but
 many engineers don't craft their communication to the business well. Common
 problems are:
@@ -31,7 +31,7 @@ being aligned what functional programming is; or why engineering should use a
 new tool. These undefined words are assumptions. And assumptions are the enemy
 of clear communication. It's assumptions that exaggerate mistakes.
 
-In comparison, hiding too much of the the technical implementation can also be
+In comparison, hiding too much of the technical implementation can also be
 detrimental. You're _denying_ the business from potentially making important
 decisions. Similar to why the
 [waterfall model](https://en.wikipedia.org/wiki/Waterfall_model) is flawed: it
@@ -73,7 +73,7 @@ preserves the data your store? How difficult is it to maintain operationally?
 if you're using Clojure and ClojureScript now. Sure it didn't seem like a
 decision the business needed to care about, but there are implications for that.
 Edn effectively locks-in your ability to move off of a Clojure stack in the
-future. While JSON is inferrior in capabilities, it keeps that option open.
+future. While JSON is inferior in capabilities, it keeps that option open.
 Alternatively, you can maintain both JSON and Edn serializations, but that
 increases your surface error to maintain. In this example, it's easy to infer
 the correct business decision, but if you're not sure, that needs to be
@@ -129,8 +129,8 @@ greater than its parts.
 <ol class="footnotes">
 <li class="footnote" id="1">A simple metric for meetings: is it worth the cost of having each person in the meeting room for the discussion for an hour? Consultants notice this more acutely than other types because of their hourly billing. It's useful, but should be more sparingly employed. <a href="#1-back" class="back">&larrhk;</a></li>
 <li class="footnote" id="2">Unless if you're a 1-person company, then only maybe. It's hard to believe if anyone has perfect technology. <a href="#2-back" class="back">&larrhk;</a></li>
-<li class="footnote" id="3">Optimization definitely has it's place, but make sure you need to pay that. If you imagine the business paying $60/hr for your time, it's it worth it for the business to improve that page load time by 10ms? <a href="#3-back" class="back">&larrhk;</a></li>
+<li class="footnote" id="3">Optimization definitely has its place, but make sure you need to pay that. If you imagine the business paying $60/hr for your time, it's it worth it for the business to improve that page load time by 10ms? <a href="#3-back" class="back">&larrhk;</a></li>
 <li class="footnote" id="4">Like optimizations, technologies are a tradeoff that should be considered. They may provide benefits as the increased risk. Can you deliver on the deadline? Can you recruit skill for this technology? What if the technology becomes abandoned? <a href="#4-back" class="back">&larrhk;</a></li>
-<li class="footnote" id="5">It's harder for a business stakeholder to be an expert at everything needed to run a business. It's easier for you to better understand the business than a stakeholder to understand technology, negotiation, manufacturing, recruiting, human resources. It doesn't hurt to try an educate them when you can though. <a href="#5-back" class="back">&larrhk;</a></li>
+<li class="footnote" id="5">It's harder for a business stakeholder to be an expert at everything needed to run a business. It's easier for you to better understand the business than a stakeholder to understand technology, negotiation, manufacturing, recruiting, human resources. It doesn't hurt to try to educate them when you can though. <a href="#5-back" class="back">&larrhk;</a></li>
 <li class="footnote" id="6">Mistakes will always happen, that's just human nature. <a href="#6-back" class="back">&larrhk;</a></li>
 </ol>

--- a/v2/content/writings/2015/13-Process-is-King.html.md
+++ b/v2/content/writings/2015/13-Process-is-King.html.md
@@ -49,15 +49,15 @@ to [surgery](http://www.who.int/patientsafety/safesurgery/checklist/en/). This
 formalization
 [reduces errors](http://www.theatlantic.com/health/archive/2014/03/save-a-brain-make-a-checklist/284438/):
 an 18% reduction in mortality in surgeries with checklists according to a
-Veterans Affairs study. Not bad for a process that's just a list actions on a
+Veterans Affairs study. Not bad for a process that's just a list of actions on a
 piece of paper.
 
 But a checklist is a straight-jacket. It's more restrictive. You'll need
-decipline to avoid the temptation to stray from the checklist. In software, the
+discipline to avoid the temptation to stray from the checklist. In software, the
 logical conclusion is to fully automate it, but we can't automate everything in
 the real world.
 
-It's important to distinguish that not every process is great a process. But
+It's important to distinguish that not every process is a great process. But
 great processes usually provide the following:
 
 - Consistency: Clear direction to achieve a goal ensuring smaller goals are met
@@ -68,14 +68,14 @@ great processes usually provide the following:
   achieve consistency.
 
 The checklist meets all three at a basic level: it's a reminder of actions to
-take to solve a larger goal; a checklist can be change while not running through
+take to solve a larger goal; a checklist can be changed while not running through
 it; and it can be given to another person to use, copy, or follow.
 
 It's interesting to see other teams' processes. NASA's space shuttle software
 [process is nearly opposite](http://www.fastcompany.com/28121/they-write-right-stuff)
 to many startups:
 
-- Psudeo-code specifications & discussions defining implementation, behavior,
+- Pseudo-code specifications & discussions defining implementation, behavior,
   and impact to code - avoids code silos
 - 9-5 work hours
 - Individual contributors focus on quality: Coders & Verifiers compete to
@@ -105,7 +105,7 @@ week to optimize every line of code for performance is a different kind of
 process that doesn't seem as sustainable or productive.
 
 Open source projects are no different. They function better with processes in
-place. What is are your guidelines to good pull requests? What is your process
+place. What are your guidelines to good pull requests? What is your process
 for cutting releases? Is there a process for
 [handling security disclosures](http://www.heavybit.com/library/video/2014-10-14-alex-gaynor)?
 Besides helping new core team members on the project, they reduce the likelihood

--- a/v2/content/writings/2015/14-going-fast-by-going-slow.html.md
+++ b/v2/content/writings/2015/14-going-fast-by-going-slow.html.md
@@ -16,7 +16,7 @@ there's always time you must dedicate to learning to keep up to date.
 
 To be blunt: there's certain things you can acquire on the job - incremental
 learnings. But for significant advancements in your thought and tooling, you'll
-need to allocate a non-trival amount of time for it (hats off to you if your job
+need to allocate a non-trivial amount of time for it (hats off to you if your job
 can offer you that kind of personal investment).
 
 Learning something completely foreign requires significant time to dedicate.

--- a/v2/content/writings/2015/15-daily-processes/index.md
+++ b/v2/content/writings/2015/15-daily-processes/index.md
@@ -27,7 +27,7 @@ All while (attempting) to achieve other goals:
 - Personal (eg - Open Source) Projects
 - Work / Career
 - Learning
-- (Re)formation of Habbits
+- (Re)formation of Habits
 
 The problem is balancing between them all. I've been trying a series of
 techniques over the few years, but rarely checked-in and reflected. I want to
@@ -81,7 +81,7 @@ to process:
   that below.
 
 The bullet journal is about organizing tasks into monthly, daily tasks with room
-to take free-form notes. It's basic layout is as follows:
+to take free-form notes. Its basic layout is as follows:
 
 - The first few pages are an index to quickly jump to pages (which are
   numbered).
@@ -102,9 +102,9 @@ to take free-form notes. It's basic layout is as follows:
 
 ![Daily Bullet Journal](/resources/15/bullet-journal.jpg)
 
-I have been doing a subset of this that involves only a daily log entries and
+I have been doing a subset of this that involves only daily log entries and
 indexes. I'll continue to expand to more of the full bullet journal over time.
-This analog form has been a lot better than most digital forms. I use a A6
+This analog form has been a lot better than most digital forms. I use an A6
 notebook which is about the size of an iPhone 6+
 
 The main problem is that there are still too many inboxes. I haven't been great
@@ -122,13 +122,13 @@ inbox with my mailbox as the review to other's requests.
 
 ## The Change
 
-All this organizing tends to let me cut up my tasks into smaller chunks that
+All this organizing tends to let me cut up my tasks into smaller chunks than
 what's needed for large tasks. It allows me to respond consistently, but
 discourages allocating full-day tasks -- such as a CLI-only Quick
 implementation, or rewriting Fox into Swift.
 
 This severely has cut into my long-term tasks and goals. There's an ideal to
-record screencasts that has been lavishing for months. I need to fully dedicate
+record screencasts that has been languishing for months. I need to fully dedicate
 a day or two in a month to work on these tasks. Similar to other habits: daily
 exercising and avoiding nail biting.
 

--- a/v2/content/writings/2016/16-domain-modeling.html.md
+++ b/v2/content/writings/2016/16-domain-modeling.html.md
@@ -5,10 +5,10 @@ url = "2016/16-domain-modeling"
 tags = ["Concepts", "Software Design"]
 +++
 
-Let's mentally build an API for an an e-commerce site. Let's say we're tasked
+Let's mentally build an API for an e-commerce site. Let's say we're tasked
 with building the cart & checkout portion of the API. Building a RESTful API
 seems like the natural choice. At first, a Cart seems like any other model
-entity in the system. But what about an multi-page checkout step?
+entity in the system. But what about a multi-page checkout step?
 
 - Allow partial updating of the Cart model (sounds like a job for PATCH). We
   need to preserve as much information as possible on the server to allow the
@@ -16,9 +16,9 @@ entity in the system. But what about an multi-page checkout step?
 - Each update needs to be validated against the current known state of the
   world. Store credit may not fully cover an order that has an upgraded shipping
   method specified later on.
-- The final cart has to be "commited" where final validations need to be
-  performed before commited.
-- An finally, the committed cart requires taking to third party APIs all along
+- The final cart has to be "committed" where final validations need to be
+  performed before committed.
+- And finally, the committed cart requires taking to third party APIs all along
   the way (shipping, credit card processing, tax calculations) as well as at the
   commit point.
 
@@ -27,9 +27,9 @@ REST doesn't provide an easy way to model this.
 We could add new custom endpoints, but that means this entity is no longer
 following REST.
 
-Another olution is the use new intermediary REST entities for each step of
+Another solution is the use new intermediary REST entities for each step of
 checkout. But that's weird. Each model only be useful for that step of the
-checkout. Not including the fact that we would need to know how to retrive the
+checkout. Not including the fact that we would need to know how to retrieve the
 intermediary model or unify the identifiers.
 
 Our REST hammer isn't going to cut it. It's just not a general enough
@@ -40,17 +40,17 @@ problem domain. Domain modeling is half of what makes good abstractions. And
 that's anything but easy.
 
 A poor abstraction is a misunderstanding of the problem. The original problem it
-ment to solve is fundamentally incorrect. Creating abstractions without initial
+meant to solve is fundamentally incorrect. Creating abstractions without initial
 contact with the problem usually births these abominations.
 
-A mediocre abstraction is leaky. That means it doesn't account for unforseen
+A mediocre abstraction is leaky. That means it doesn't account for unforeseen
 situations. Special cases and work-around code are common symptoms. First-level
 refactors tend to be this level inside applications. It's perfectly acceptable
 for frontend applications to have this level of abstraction. They only need to
 solve the solution for the specific context in mind and not future situations.
 
 A decent abstraction solves the problem well, but doesn't factor in expanding
-scope. It doesn't provide an obviously pattern to apply or extension point. Lots
+scope. It doesn't provide an obvious pattern to apply or extension point. Lots
 of libraries start like this. Many libraries fall into this category. And it's
 fine if the scope they're solving is a finite problem, such as implementing a
 specification. Something like REST would be here. But solving a general problem
@@ -61,7 +61,7 @@ scope. It does provide a pattern to apply or an extension point for new
 capabilities. The difficulty in reaching this level as a general purpose library
 is rare and difficult.
 
-In short, great abstractions is far from implementation details but close enough
+In short, great abstractions are far from implementation details but close enough
 to model the problem at hand. That's not easy.
 
 Programmatic abstractions minimize the surface area between both sides of the
@@ -95,11 +95,11 @@ should have a small surface area. That's one of the main arguments of
 [GraphQL](http://graphql.org/) over REST: there are no ad-hoc endpoints for the
 client to know about.
 
-That's not to saying that class-based modeling of problem domain is wrong. For
+That's not to say that class-based modeling of problem domain is wrong. For
 example, [Joda-time]() is abstracting the complex, inconsistent rules of time
 that makes it hard to abstract in a clean, concise interface. Abstracting time
 is fundamentally difficult (and ever changing) problem. At worst, these
-libraries tend to inform incorrect or ambigious usages.
+libraries tend to inform incorrect or ambiguous usages.
 
 We should minimize introducing
 [human complexity](https://www.youtube.com/watch?v=l3nPJ-yK-LU) and prefer

--- a/v2/content/writings/2016/17-observation/index.md
+++ b/v2/content/writings/2016/17-observation/index.md
@@ -8,23 +8,23 @@ tags = ["Concepts"]
 The more you learn, the more this skill seems to be necessary. When missing a
 bug or a refactor opportunity, I wonder how did I miss this? Sure, everyone
 wants to learn from their mistakes. But noticing the little details gives you
-the opportunity to adapt. Massive function definitions starts off looking like
-an common pattern for code that needs to be refactored. Those dozen one-letter
+the opportunity to adapt. Massive function definitions start off looking like
+a common pattern for code that needs to be refactored. Those dozen one-letter
 variables names probably should be better named. Shadowing a variable is prone
 to introduce errors in the future. All those mental notes form from being able
 to observe it.
 
-By observing, I mean decerning the signal from the noise of inputs. And it
+By observing, I mean discerning the signal from the noise of inputs. And it
 doesn't have to apply to programming. How can you make your food taste better?
 The video game, [Braid][braid], is a great example. It teaches players how its
 rules of time manipulation lead to certain implications that are required to
 solve puzzles.
 
-Observation an interesting commonality among many skills. [Jiro][jiro] remarks
+Observation is an interesting commonality among many skills. [Jiro][jiro] remarks
 how he could be a better chef if only he had the tasting ability of Joel
-Robuchon. Breaking a bad habbit first requires noticing that it's a bad habbit
+Robuchon. Breaking a bad habit first requires noticing that it's a bad habit
 in the first place. The first step to addiction is noticing (and admitting) you
-have a problem. Great designers try to solve for the sutle details of human
+have a problem. Great designers try to solve for the subtle details of human
 interaction with the products they build.
 
 ![Image from "Jiro, Dreams of Sushi"](jiro.jpg)
@@ -38,16 +38,16 @@ How do you become more observant? I'm not sure. There's a lot of little ways to
 experience more:
 
 - Meditation focuses on watching your breathing instead of wandering your mind.
-- Hiking or climbing focuses on you physical movement.
+- Hiking or climbing focuses on your physical movement.
 - Drawing focuses on replicating details of the subject being drawn.
-- Write in a journal (eg - food journal, finance journale).
+- Write in a journal (eg - food journal, finance journal).
 - Taking up professional photography.
 - Playing video games
 - Standup Comedy
 - Sports
 - Etc.
 
-They seems to have one thing in common: they all require noticing a sensory
+They seem to have one thing in common: they all require noticing a sensory
 experience. It's not just performing one of these activities, but getting
 skilled at it makes you more observant.
 

--- a/v2/content/writings/2016/18-editing-text-basics.html.md
+++ b/v2/content/writings/2016/18-editing-text-basics.html.md
@@ -59,7 +59,7 @@ Arrays have great performance for reading any character. But making changes
 
 The performance characteristics can be _shifted_ if you switch from a standard
 resizable array to a resizable [circular buffer][circular-buffer] to allow fast
-inserts on either end. But there still poor performance in most the common case
+inserts on either end. But there is still poor performance in most the common case
 of editing in the middle of the text.
 
 # Array of Strings
@@ -79,7 +79,7 @@ when reading and writing from the buffer.
 # Gap Buffer
 
 When the programming language supports direct manipulation of bytes, a common
-data structure is call the [Gap Buffer][gap-buffer]. It's simply an array with a
+data structure is called the [Gap Buffer][gap-buffer]. It's simply an array with a
 "gap" of free space that's used to allow efficient edits that are close to each
 other. The gap is moved to the desired location by shifting characters. Since
 moving the gap buffer is the most expensive, it is generally only done when an
@@ -94,7 +94,7 @@ buffer = ['a', 'b', None, None, None, 'c']
 ```
 
 The gap moves to where edits are being made. This is done by shifting the
-characters to either side of the buffer. The follow examples demonstrate how
+characters to either side of the buffer. The following examples demonstrate how
 basic operations behave.
 
 ### Moving to the Beginning

--- a/v2/content/writings/2016/19-design-of-software-solutions.html.md
+++ b/v2/content/writings/2016/19-design-of-software-solutions.html.md
@@ -11,8 +11,8 @@ identify their characteristics and the tradeoffs they make.
 
 ## Architect the Software After the Current Problem
 
-The easiest is way to model software. There's no need to take in consideration
-of future solutions the user made want.
+The easiest is way to model software. There's no need to take into consideration
+of future solutions the user may want.
 
 Sometimes this is what you need. If you're writing a throw-away program, the
 fastest possible way to implement it is to codify for the exact problem you're
@@ -49,7 +49,7 @@ some degree, but it lacks the ability to remove features. For example, what if
 the `Vehicle` assumed that a car needs to be powered by gasoline? Our hybrid
 vehicle becomes harder to introduce.
 
-This is same for shell scripts – most scripts will hardcode values and make
+This is the same for shell scripts – most scripts will hardcode values and make
 assumptions to its execution environment.
 
 These kinds of programs are cheaper to produce, but more expensive to change.
@@ -102,12 +102,12 @@ for mpg, miles in vehicles:
 Since the CPU fetches memory in chunks, we waste some of the memory fetch to the
 extra fields each vehicle has. This means more memory fetches. Looking at a
 [latency chart][latency chart], it's easy to imagine many of these extra fetches
-adding up to a noticable additional time.
+adding up to a noticeable additional time.
 
 No doubt performance-centric designs sacrifice hardware abstractions. Most of
 this software couples to the exact hardware it executes on: a computer chip; or
 the kind of CPU architecture. Changing to another platform may waste all the
-effort put in to turning the execution performance.
+effort put in to tuning the execution performance.
 
 These systems are also more expensive to build. They cater to the needs of the
 computer and optimize less for the readability of the programmer. A logical
@@ -123,15 +123,15 @@ the machine, it comes at the cost of future flexibility.
 
 This is harder to describe.
 
-Modeling software toward small abstractions avoids having the directly model
+Modeling software toward small abstractions avoids having to directly model
 either end. Instead, it's road less traveled. Mostly because it's a chicken-egg
-problem: a good abstraction requires a in-depth knowledge of the problem at
+problem: a good abstraction requires an in-depth knowledge of the problem at
 hand; but the best way to know the problem well is to try and solve it multiple
 times.
 
 A great example of an abstraction is how many HTTP interfaces are defined:
 [rack][rack], [wsgi][wsgi], [go/http's Handler][go-http]. They naturally provide
-the notion of middleware. Middleware can solve parts of what is needed to for an
+the notion of middleware. Middleware can solve parts of what is needed for an
 HTTP request:
 
 - Divide work up by request (eg - URI routes, HTTP method, etc.)

--- a/v2/content/writings/2016/20-two-kinds-of-abstractions.html.md
+++ b/v2/content/writings/2016/20-two-kinds-of-abstractions.html.md
@@ -74,7 +74,7 @@ interface PaymentProcessor {
 This kind of abstraction is usually more procedural — following an ordered
 series of method invocations.
 
-Payment interface above could possible support many implementations:
+Payment interface above could possibly support many implementations:
 
 - Stripe
 - Braintree
@@ -105,7 +105,7 @@ A well-trodden path is parsing text. There's many [talks][swift-parsers] and
 [articles][wikipedia] that demonstrate composing smaller parsers into larger
 ones. Data mapping between two similar data structures is a related problem that
 also has relatively clear composition traits. Composing a solution gives future
-flexibility to adapt to changing requirements of the problem being solve.
+flexibility to adapt to changing requirements of the problem being solved.
 
 In composable abstraction, interfaces define how each piece communicates to one
 another. An interface for composability looks less procedural, and more

--- a/v2/content/writings/2016/21-tldr-programming-concepts.html.md
+++ b/v2/content/writings/2016/21-tldr-programming-concepts.html.md
@@ -10,14 +10,14 @@ is to build upon existing concepts, but as you add more concepts you run the
 risk of being inconsistent.
 
 So with at most two sentences, I present a list of common programming concepts.
-This goes without warning that lossy compression is inevitable.
+This goes without saying that lossy compression is inevitable.
 
 - **Data**: Ones and zeros.
 - **Values**: Meaningful data.
 - **Types / Encodings**: Interpretations of values.
 - **State**: A value that changes over time. Usually also considered a Value.
 - **Variables**: Names for values over time.
-- **Collections**: A value that's a a group of values of same type.
+- **Collections**: A value that's a group of values of same type.
 - **Structs**: A value that's a group of values with possibly differing types.
 - **Classes**: Structs with functions that have itself as the first argument.
 - **Inheritance**: A concise way to implement a class by referring to part of
@@ -33,11 +33,11 @@ This goes without warning that lossy compression is inevitable.
 - **Type Classes**: Generic Interfaces.
 - **Monad**: An interface defining the expected behavior for `map`.
 - **Functor**: An interface defining the expected behavior for `apply`.
-- **Pointers**: A value that indicates where to find another value. An home
+- **Pointers**: A value that indicates where to find another value. A home
   address is a pointer to a home.
 - **Big-O Notation**: A method to estimate the number of main-memory operations
 - **Slice**: A value that is a pointer and length into an existing collection
-- **Value Objects**: An struct / class with equality and hashCode semantics.
+- **Value Objects**: A struct / class with equality and hashCode semantics.
 - **Object-Oriented Programming**: The concept of classes talking to each other
   using value objects.
 - **Procedure**: A sequence of operations to execute. Most programming languages
@@ -51,7 +51,7 @@ This goes without warning that lossy compression is inevitable.
 - **Code**: A value that is a series of operations
 - **AST (Abstract Syntax Tree)**: Hierarchy of typed code
 - **Program**: A collection of code that a computer that can execute.
-- **Compiler**: Program that take code and produce programs.
+- **Compiler**: Program that takes code and produce programs.
 - **Interpreter**: A program that executes code without producing a program.
 - **Emulator**: A program that mimics the behavior of hardware.
 - **Virtual Machine**: A computer emulator where the hardware may not actually
@@ -60,7 +60,7 @@ This goes without warning that lossy compression is inevitable.
 - **Dynamic**: Known at execution-time.
 - **Type Checker**: A program that validates what types flowing through your
   code.
-- **Type Inference**: A compiler or interpreter feature can that deduce types
+- **Type Inference**: A compiler or interpreter feature that can deduce types
   without always explicitly specifying it in code.
 - **Optimization**: Writing code for the computer first, instead of humans.
 - **Performance**: Turning memory operations for lower frequency, and higher
@@ -88,7 +88,7 @@ implications result from these definitions:
 - How would you describe a plugin?
   - How does it differ from library?
 - Is the `assert` replacement in [pytest](http://pytest.org/latest/) a macro?
-- Is Clojure a compiler or intepreter in these definitions?
+- Is Clojure a compiler or interpreter in these definitions?
   - Clojure code [always compiles](http://clojure.org/reference/evaluation) to
     bytecode before executing (eg - in a REPL)
   - Clojure code can be compiled ahead-of-time into a jar

--- a/v2/content/writings/2016/22-whats-your-engineering-culture.html.md
+++ b/v2/content/writings/2016/22-whats-your-engineering-culture.html.md
@@ -5,16 +5,16 @@ url = "2016/22-whats-your-engineering-culture.html"
 tags = ["Concepts", "Processes"]
 +++
 
-When evaluating companies, its utmostly important to learn about the engineering
-culture. Culture for a company is simular to scope for code – culture provides a
+When evaluating companies, it's of utmost importance to learn about the engineering
+culture. Culture for a company is similar to scope for code – culture provides a
 context for getting work done.
 
 Companies advertise their culture, but note that each company has a different
 culture. There's plenty of articles about culture, so I won't bother covering
 that. Just remember they aren't necessarily the same. Companies tend not to be
 explicit about making sure their process matches what you expect. Be suspicious
-for a company that can't explain it's culture because that just means they're
-not activitely trying to cultivate one. And that means it's implicitly defined
+for a company that can't explain its culture because that just means they're
+not actively trying to cultivate one. And that means it's implicitly defined
 by the leaders of the company. Even if they choose not to define it.
 
 ## Basics
@@ -44,11 +44,11 @@ noting that these are important for companies larger than a handful of people:
 - Are there regular **one-on-ones**? No doubt large companies have this. That's
   because one-on-one is a safer way for some employees to voice concerns. But a
   scheduled one-on-one provides a useful way to raise concerns privately without
-  having to require employees the initiate the effort.
+  having to require employees to initiate the effort.
 - Are there regular **retrospectives**? Not just the one for that outage that
   occurred yesterday, but a regular one. It's similar to a one-on-one, but for
   teams. They provide ways for a team to raise concerns. The scheduled time
-  reinfornces that this kind of feedback loop is valued.
+  reinforces that this kind of feedback loop is valued.
 - Do employees work **long hours**? It's not necessarily bad when employees work
   overtime. It could be a sign of engineers invested in the product or a
   specific time-sensitive deadline. But a common occurrence of late nights isn't
@@ -64,7 +64,7 @@ the power-users of their product.
 
 ## Growth
 
-Finally, companies can go above an beyond if they are willing in invest in your
+Finally, companies can go above and beyond if they are willing to invest in your
 continual refinement of your craft. Few companies do this. To be fair, a lot of
 it does depend on the person. It's difficult for an organization to offer this
 well.
@@ -78,9 +78,9 @@ well.
   Hackweek.
 - Does the company provide **a process for evaluating and introducing new
   technologies**? Besides just throwing employees into the deep-end, there
-  should be ways for to help explore and train with new technologies.
+  should be ways to help explore and train with new technologies.
 - How does the company **train junior developers**? Unfortunately, there isn't
-  an obvious answer to this. But is important for the company's bus-factor.
+  an obvious answer to this. But it is important for the company's bus-factor.
   Teaching a useful way to solidify knowledge for senior developers. Sadly not
   every developer will like doing this.
 

--- a/v2/content/writings/2016/23-reading-code.html.md
+++ b/v2/content/writings/2016/23-reading-code.html.md
@@ -7,7 +7,7 @@ tags = ["Processes"]
 
 I'm fascinated by how engineers read and interpret code that they work on a
 daily basis. It's no doubt different for everyone, but few explain how they go
-about and understand a unfamiliar codebase.
+about and understand an unfamiliar codebase.
 
 For me, being comfortable in a codebase usually means two things:
 
@@ -84,7 +84,7 @@ def fields_for_model(model, fields=None, exclude=None, widgets=None,
 ```
 
 Without looking much into the other code around it, we can make (roughly) two
-kinds of interferences: assumptions and assertions in alternating fashion.
+kinds of inferences: assumptions and assertions in alternating fashion.
 
 ## 1. Assumptions
 
@@ -94,7 +94,7 @@ kinds of interferences: assumptions and assertions in alternating fashion.
   an underscore for private / protected functions as per python's coding
   conventions
   - There's also no other private or protected indicator that may indicate that
-    if the developer was for accustomed to programming in another language.
+    if the developer was more accustomed to programming in another language.
 - The function name indicates getting some fields (a collection?) given a model
   (a form model?)
 
@@ -122,7 +122,7 @@ kinds of interferences: assumptions and assertions in alternating fashion.
 - `fields` and `exclude` are probably whitelists and blacklists respectively
 - `formfield_callback` is an alternative constructor for these formfield
   instances
-- It looks like this function read's some or all of a models' fields. Models are
+- It looks like this function reads some or all of a models' fields. Models are
   from the database or elsewhere. The return value is a dictionary of field
   names to some field model.
 
@@ -140,13 +140,13 @@ random. But usually exploring a codebase is driven by a goal – usually to make
 change to the software.
 
 When I navigate _down_ into more implementation details, the goal is to
-understand how or what is being accomplish in a piece of code. This means I need
+understand how or what is being accomplished in a piece of code. This means I need
 to understand how a piece of code works, what arguments a function or class
 expects, etc.
 
-Learning context of the a given code's execution when I navigate _up_ to find
+Learning context of a given code's execution when I navigate _up_ to find
 usages of the code I was reading. This helps understand the bigger picture of
-why the some code was written and if it can make assumptions about its
+why some code was written and if it can make assumptions about its
 execution. It's only natural for a function to be implemented against the cases
 it's known to encounter.
 

--- a/v2/content/writings/2020/24-check.statem.html.md
+++ b/v2/content/writings/2020/24-check.statem.html.md
@@ -6,7 +6,7 @@ tags = ["Testing", "QuickCheck"]
 +++
 
 One of the most interesting parts of generative testing (aka
-[QuickCheck][QuickCheck]). Is state machine testing. The original purpose I
+[QuickCheck][QuickCheck]) is state machine testing. The original purpose I
 built [Fox][Fox] was to explore state machine testing. In particular, the talk
 from John Hughes video was inspirational to exploring this further:
 
@@ -33,7 +33,7 @@ suite:
   case is _always_ tested.
 - Testing pure functions (arguably, normal generative testing can help too)
 
-With the most common argument against generating testing comes with the
+With the most common argument against generative testing comes with the
 complexity of writing generative tests, or more specifically:
 
 > Isn't writing a generative test equivalent to implementing the code I'm
@@ -76,7 +76,7 @@ Unfortunately, I don't do any work in Erlang, so I've been working on writing a
 state machine generator based on the papers & talks of John Hughes. It's called
 [check.statem][check.statem].
 
-It's possible to built a basic state machine, one that has little to no
+It's possible to build a basic state machine, one that has little to no
 dependencies on another transition:
 
 ```clojure
@@ -151,7 +151,7 @@ is valid operation (or breaks the constraints of the model state machine).
 
 It's still relatively new (only snapshots versions are on
 [Clojars][check.statem.clojars] right now), but I've been writing some code in
-an example project to play around an it's been enlightening from first-hand
+an example project to play around and it's been enlightening from first-hand
 experience. The kind of signal-to-noise that John mentions happens on a regular
 basis that still surprises (and delights) me: "There's no way this is the
 smallest test case."
@@ -171,7 +171,7 @@ There's some interesting personal experiences about using generative state
 machine testing that should be written up at some point.
 
 In terms of features for check.statem, the Erlang QuickCheck does have some
-really nice features when in comes to parallel testing that I would want to
+really nice features when it comes to parallel testing that I would want to
 implement at some point in the future.
 
 [QuickCheck]: https://hackage.haskell.org/package/QuickCheck

--- a/v2/content/writings/2024/learning-kubernetes.md
+++ b/v2/content/writings/2024/learning-kubernetes.md
@@ -7,7 +7,7 @@ draft = true
 1. Deploy using Talos
    - Caveat: ip changes requires updating configuration
 2. Kubectl
-   - configurationg loading issue to make sure it loads kubectl
+   - configuration loading issue to make sure it loads kubectl
 3. Setting up tailscale
    - https://www.youtube.com/watch?v=wjDtoe-CYoI
 4. Setup 1password operator

--- a/v2/content/writings/2024/toml-crashcourse.md
+++ b/v2/content/writings/2024/toml-crashcourse.md
@@ -78,7 +78,7 @@ The following basic types are supported for values:
 - arrays using `[]`
 - maps using `{}`
 - dates & times using [RFC3339] format without any strings (eg -
-  `2024-09-19T14:22:16-07:00`). You can provide be date only or time only
+  `2024-09-19T14:22:16-07:00`). You can provide a date only or time only
 
 Note that keys must always be strings (like JSON).
 

--- a/v2/content/writings/2024/ts-retro.md
+++ b/v2/content/writings/2024/ts-retro.md
@@ -12,7 +12,7 @@ is based on being away from conventional web dev for many years.
 
 ## Getting Started is Easy
 
-Having not have to build anything yourself is can be nice if you want to deliver
+Not having to build anything yourself can be nice if you want to deliver
 something quickly. This is doubly true when Svelte allows you to pull a library
 that doesn't have explicit view framework support (eg - ReactJS). Need auth? Use
 [AuthJS][authjs]. Everything is so [easy][simple is not easy].
@@ -43,9 +43,9 @@ how much effort the community puts to add types to as much as possible.
 
 [Zod][zod] is great. It's a concise validation and parsing library like
 Clojure's [Schema][clojure-schema]. [TRPC][trpc] is good for jump to definition
-and easy of having backend-only and backend/frontend endpoints.
+and ease of having backend-only and backend/frontend endpoints.
 
-[Tailwind][tailwind] is also has excellent VS Code integration.
+[Tailwind][tailwind] also has excellent VS Code integration.
 
 ## Destructuring is Nice
 
@@ -69,7 +69,7 @@ Yes, there's [superjson][superjson].
 Javascript always had two types to represent the absent of something, but
 Typescript makes it more annoying to deal with. Now you have to make sure your
 empty types line up to functions and fields you pass through. It's just an ugly
-wort of the the language.
+wart of the language.
 
 ## Security
 
@@ -88,7 +88,7 @@ you're not installing something bad. Oh and make sure you don't make any typos!
 
 Yes it's typesafe, but its common to generate large type check errors that are
 difficult to diagnose or troubleshoot. It almost reminds me of C++ template
-errors. And that's not a good thing. I've litteral spent hours debugging type
+errors. And that's not a good thing. I've literally spent hours debugging type
 errors in C++ before. I have spent 15-30 minutes trying to understand various
 type errors in typescript.
 
@@ -102,7 +102,7 @@ cause.
 ## Slow Editing Feedback Loops
 
 Randomly in [Cursor][cursor] or [VS Code][vscode] will take up to a couple of
-minutes to some trival action. It's bad:
+minutes to some trivial action. It's bad:
 
 1. Daily, I have a few files that will take 1-5 minutes to save. It's not
    consistent and just happens randomly. I'm close to saying this negates almost
@@ -110,7 +110,7 @@ minutes to some trival action. It's bad:
 1. Also, pasting code is randomly slow as well. This applies to any file type
    (including writing this blog post in markdown!). Slow pasting can take up to
    1 minute to complete, where any editing commands are buffers / frozen.
-1. Type checking is slow that I just miss type errors when editing. And since
+1. Type checking is so slow that I just miss type errors when editing. And since
    Typescript type errors are optional, I don't really notice an issue until
    later. This creates a middle ground that's worst of both worlds. I can edit
    as fast as like I do without types, but have to come back to try to

--- a/v2/content/writings/2025/adt.md
+++ b/v2/content/writings/2025/adt.md
@@ -84,7 +84,7 @@ Open enumerations mean “more values may be added in the future, and it is impo
 
 Enum sum types are typically closed enumerations. The language enforces exhaustive checks, providing useful developer ergonomics when adding a new type to the sum type.
 
-Closed enums are better for app developers, while open enums for library writers minimizing breaking changes.
+Closed enums are better for app developers, while open enums are better for library writers minimizing breaking changes.
 
 ## Footnotes
 

--- a/v2/content/writings/2025/datastar.md
+++ b/v2/content/writings/2025/datastar.md
@@ -116,7 +116,7 @@ It's worth remembering that most attributes are just JS expressions. For example
 
 ## `el` for current element
 
-`el` is a special variable the refers to the current element.
+`el` is a special variable that refers to the current element.
 
 ## `$` for signals
 


### PR DESCRIPTION
## Summary
- Fix spelling, grammar, and punctuation errors across 32 content files
- Covers compendium articles, resume, and writings from 2014–2025
- No content changes — only corrections to existing text (149 lines changed)